### PR TITLE
Pin the version of ghcHEAD

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,9 +7,17 @@
 #   Build using GHC built from source tree $GHC_TREE:
 #       nix build -f --arg ghc "(import build.nix {ghc-path=$GHC_TREE;})"
 #
+let
+  baseNixpkgs = (import <nixpkgs> {}).fetchFromGitHub {
+    owner = "nixos";
+    repo = "nixpkgs";
+    rev = "ff0641ceea9e652e0f21f6805a2b618cde6597a2";
+    sha256 = null;
+  };
+in
 
 # ghc: path to a GHC source tree
-{ ghc ? (pkgs: pkgs.haskell.compiler.ghcHEAD) }:
+{ ghc ? import ./ghc.nix }:
 
 let
   jailbreakOverrides = self: super: {
@@ -17,6 +25,7 @@ let
   };
 
   overrides = self: super: rec {
+    # Should this be self?
     ghcHEAD = ghc super;
 
     haskellPackages =
@@ -70,12 +79,5 @@ let
             };
           };
       in baseHaskellPackages.extend overrides;
-  };
-
-  baseNixpkgs = (import <nixpkgs> {}).fetchFromGitHub {
-    owner = "nixos";
-    repo = "nixpkgs";
-    rev = "ff0641ceea9e652e0f21f6805a2b618cde6597a2";
-    sha256 = null;
   };
 in import baseNixpkgs { overlays = [ overrides ]; }

--- a/ghc.nix
+++ b/ghc.nix
@@ -1,0 +1,19 @@
+# Specify the precise commit of GHC that we are going to use by default
+nixpkgs:
+let spec =
+  {
+    version = "8.6.20180622";
+    src =
+      nixpkgs.fetchgit {
+        url = "git://git.haskell.org/ghc.git";
+        rev = "c35ad6e0b3c62976e6251f1e9c47fe83ff15f4ce";
+        sha256 = "1n4pa7igyx3dck8mx1kgzb52hs44x7c4bxd2w80q68z0qwizfkny";
+      };
+  };
+in
+
+(nixpkgs.haskell.compiler.ghcHEAD.override
+    { version = spec.version
+    ; bootPkgs = nixpkgs.haskell.packages.ghc822; }).overrideAttrs(oldAttrs:
+    { src = spec.src; })
+


### PR DESCRIPTION
It currently points to the HEAD commit on the 8.6 branch

We should update `ghc.nix` to point to the right tag when the various RCs are released.